### PR TITLE
Fix symlinking error

### DIFF
--- a/cli/mmt/engine.py
+++ b/cli/mmt/engine.py
@@ -185,7 +185,10 @@ class NeuralDecoder(object):
         tgt_model_vocab = os.path.join(output_dir, 'model.vcb')
 
         if not os.path.isfile(tgt_model_vocab):
+          try:
             os.symlink(src_model_vocab, tgt_model_vocab)
+          except OSError:
+            pass
 
         env = self._get_env()
         hparams_p = 'batch_size=%d' % batch_size


### PR DESCRIPTION
The problem is I before packing a model, I copied the runtime folder to another place. Then performed the packing. Then I copied the runtime folder and resume the training but it didn't work. 
When runtime folder is copied and MMT training is resumed, symlinking on an already existing file throws error (tries to symlink the target vocab file). 
This OSError is not caught by the code. 