### PR TITLE
Use 'best_loss' corresponding to avg valid loss for early stopping

### DIFF
--- a/cli/train.py
+++ b/cli/train.py
@@ -58,7 +58,7 @@ def _get_loss(event_file):
 
             if len(event.summary.value) > 0:
                 value = event.summary.value[0]
-                if value.tag == 'loss':
+                if value.tag == 'best_loss':
                     return event.step, value.simple_value
 
     raise AssertionError('could not find "loss" value in event file: ' + event_file)
@@ -76,7 +76,8 @@ class TrainActivity(StatefulActivity):
     def _training_should_stop(self):
         def _loss_iterator(_events, limit):
             count = 0
-            for e in _events:
+            # the first validation event written (last in list) has no 'best_loss'
+            for e in _events[:-1]:
                 step, loss = _get_loss(e)
                 if step % self.state.save_interval_updates == 0:
                     yield loss


### PR DESCRIPTION
I have verified this to be working as early stopping would be expected to work, by simply training a model.

The existing implementation stopped training after ~120k iterations, producing a BLEU of about 34 for my test set, whereas the new code trains for ~380k iterations, achieving 35.7 BLEU points. 

For context and intuition behind the changes, see #509 which also links to corresponding fairseq ticket regarding the 'best_loss'.

If you agree with this change, I hope it can be released pretty fast, as I would consider this a pretty crucial bug.

Closes #509 