### PR TITLE
Replace os.rename with sh.util for cross-device compatibility

### DIFF
--- a/cli/create.py
+++ b/cli/create.py
@@ -100,7 +100,7 @@ class CreateActivity(StatefulActivity):
         if os.path.exists(output_nn_path):
             shutil.rmtree(output_nn_path)
 
-        os.rename(self.state.nn_path, output_nn_path)
+        shutil.move(self.state.nn_path, output_nn_path)
 
     def run(self):
         self._logger.info('Training started: engine=%s, lang_pair=%s__%s' %


### PR DESCRIPTION
If running MMT on a machine with multiple file systems, eg. could be
a mounted volume for the runtime directory, using `os.rename` causes
the `./mmt create` command to fail with 'Invalid cross-device link'.
See: https://stackoverflow.com/questions/42392600/oserror-errno-18-invalid-cross-device-link

Sample error from my logs:
```
ERROR Unexpected exception: [Errno 18] Invalid cross-device link: '/opt/mmt/runtime/de_pt_engine/tmp/training/nn_model' -> '/opt/mmt/engines/de_pt_engine/models/decoder/de__pt'
```

If instead using `shutil.move`, same-device move operations will use
`os.rename` under the hood, whereas different devices are handled by
transparently using `os.copy` followed by `os.remove`, making sure
that invalid cross-device errors never occur no matter the file system
layout of the machine.