### PR TITLE
Fix bug with multilingual engines causing different translations

### DIFF
--- a/src/decoder-neural/src/main/python/mmt/decoder.py
+++ b/src/decoder-neural/src/main/python/mmt/decoder.py
@@ -10,7 +10,7 @@ import torch
 from fairseq.models.transformer import TransformerModel
 from fairseq.sequence_generator import SequenceGenerator
 
-from mmt import textencoder
+from mmt import textencoder, SubwordDictionary
 from mmt.alignment import make_alignment, clean_alignment
 from mmt.tuning import Tuner, TuningOptions
 
@@ -149,6 +149,18 @@ class MMTDecoder(object):
         self._nn_needs_reset = True
         self._checkpoint = None
 
+        # Handling of multilingual engines with varying vocab sizes with resistance
+        # to negative logits, for which we need to override `model.get_normalized_probs`
+        # and keep track of the original vocabulary sizes of each model to do masking
+        self._get_normalized_log_probs = self._model.get_normalized_probs
+        self._max_vocab_size = len(checkpoints.task.target_dictionary)
+        self._vocab_sizes = dict()
+        for pair, checkpoint in checkpoints._checkpoints.items():
+            dict_path = os.path.join(checkpoint._checkpoint_path, "model.vcb")
+            vocab_size = SubwordDictionary.size_of(dict_path)
+            language_pair = tuple(pair.split("__"))
+            self._vocab_sizes[language_pair] = vocab_size
+
     # - High level functions -------------------------------------------------------------------------------------------
 
     def test(self):
@@ -190,12 +202,49 @@ class MMTDecoder(object):
 
     # - Low level functions --------------------------------------------------------------------------------------------
 
+    def _set_normalized_probs_wrapper(self, source_lang, target_lang):
+        """
+        Since we alter the vocabulary and embedding matrix sizes to make multiple models
+        of varying sizes compatible with the same instance of TransformerModel, we have
+        to do some hacky overriding to make sure that the additional words in our extended
+        output logits cannot be be predicted during BeamSearch decoding. At the same time we
+        have to make sure that we don't cause the softmax to behave differently.
+        We solve this by treating the extended tokens the same way <PAD> is treated by setting
+        their log probability to negative infinity, and ensuring they are removed before
+        softmax is applied.
+        """
+        actual_vocab_size = self._vocab_sizes[source_lang, target_lang]
+        pad_size = self._max_vocab_size - actual_vocab_size
+
+        def wrapper(*args, **kwargs):
+            # net_output can be both a tuple and a list, so we have to handle both
+            net_output, *args_rest = args
+            logits, *net_output_rest = net_output
+
+            # truncate log probs to actual vocab size for proper softmax distribution
+            fixed_logits = logits[:, :, :actual_vocab_size]
+
+            # stitch *args tuple back together again with fixed_logits
+            fixed_args = ((fixed_logits, *net_output_rest), *args_rest)
+
+            # call the original _get_normalized_log_probs with fixed_logits
+            log_probs = self._get_normalized_log_probs(*fixed_args, **kwargs)
+
+            # pad the probs to extended size (applied as left/right padding to last dim)
+            padded_probs = torch.nn.functional.pad(
+                log_probs, (0, pad_size), mode="constant", value=-math.inf
+            )
+            return padded_probs
+
+        self._model.get_normalized_probs = wrapper
+
     def _reset_model(self, source_lang, target_lang):
         checkpoint = self._checkpoints.load(source_lang, target_lang)
 
         if self._nn_needs_reset or checkpoint != self._checkpoint:
             self._model.load_state_dict(checkpoint.state, strict=True)
             self._checkpoint = checkpoint
+            self._set_normalized_probs_wrapper(source_lang, target_lang)
             self._nn_needs_reset = False
 
     def _tune(self, suggestions, epochs=None, learning_rate=None):


### PR DESCRIPTION
This bugfix relates to and closes #531, closes #527.
Both bugs were originally thought to relate to handling or rare words, which was partially true.

The problem arises with how ModernMT handles fitting multiple models of varying vocabulary sizes into the same instance of `TransformerModel` from `fairseq`. MMT currently handles this by fitting all models' weights to the size of the largest embedding matrix, padding with zeros as necessary. This works fine when embedding the input, as the padded tokens never occur in the input. As the embedding matrix is however reused as the parameter for the `output_layer` in FAIRSeq, this now creates several logits with probability 0 for models that aren't the one with the largest vocabulary in the multilingual engine. For the most part, this has limited impact in real life scenarios, outside if small but non-critical changes to the softmax distribution. It can however happen that some model will predict a full distribution of logits with negative values, which all of a sudden makes one of the padded tokens the most likely logit with its value of 0. This causes the errors we see in issues #531 and #527, and used to cause exceptions in MMT 4.2.

To solve this, I suggest one workaround in this PR, although it may be possible to solve this in a more elegant way. The solution is quite simple, by simply overriding the `get_normalized_probs` function in the `TransformerModel` from `fairseq` with a wrapped function that truncates the logits to the original vocabulary size of the model, before calling the original `get_normalized_probs` function. It then subsequently pads the probability distribution returned by `get_normalized_probs` with `-math.inf` for all the padded tokens (in a similar way to how the <PAD> token is handled in fairseq's `SequenceGenerator`. This should result in inference being treated the exact same way for engines consisting of one/many models.

I have tested this fix and found that it works for both regular translation and for translation with context memories, without any noticable impacts on throughput.